### PR TITLE
Add unsolicited IP assignment

### DIFF
--- a/draft-ietf-masque-ip-proxy-reqs.md
+++ b/draft-ietf-masque-ip-proxy-reqs.md
@@ -162,7 +162,8 @@ will either assign a range of its choosing to the client, or decline the
 request. For symmetry, the server may request assignment of an IP address range
 from the client, and the client will either assign a range or decline the
 request. Endpoints will also have the ability to assign an IP address range to
-their peer without having received a request.
+their peer, and to communicate that assignment to the peer, without having
+received a request.
 
 ## Route Negotiation
 

--- a/draft-ietf-masque-ip-proxy-reqs.md
+++ b/draft-ietf-masque-ip-proxy-reqs.md
@@ -161,7 +161,8 @@ optionally specifying a preferred range. In response to that request, the server
 will either assign a range of its choosing to the client, or decline the
 request. For symmetry, the server may request assignment of an IP address range
 from the client, and the client will either assign a range or decline the
-request.
+request. Endpoints will also have the ability to assign an IP address range to
+their peer without having received a request.
 
 ## Route Negotiation
 


### PR DESCRIPTION
As proposed by @mirjak in #31, in some cases it might be useful to assign an IP address range even if there was no request.

Closes #31.